### PR TITLE
HTTP 204 response fix and query support on list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 5.5
   - 5.6
   - 7
-  - nightly
   - hhvm
 
 addons:
@@ -24,7 +23,7 @@ install:
   - composer install --no-interaction
 
 script:
-  - phpunit
+  - ./vendor/bin/phpunit
 
 after_script:
   - vendor/bin/test-reporter

--- a/src/Endpoints/Traits/DeletesResource.php
+++ b/src/Endpoints/Traits/DeletesResource.php
@@ -16,6 +16,6 @@ trait DeletesResource
     {
         $response = $this->client->delete("{$this->getEndpoint()}/{$uuid}");
 
-        return $this->toResponse($response);
+        return null;
     }
 }

--- a/src/Endpoints/Traits/ListsResource.php
+++ b/src/Endpoints/Traits/ListsResource.php
@@ -9,11 +9,14 @@ trait ListsResource
     /**
      * Get all from resource.
      *
+     * @param array $query query parameters of list request
      * @return Response
      */
-    public function all()
+    public function all(array $query = [])
     {
-        $response = $this->client->get($this->getEndpoint());
+        $response = $this->client->get($this->getEndpoint(), [
+            'query' => $query
+        ]);
 
         return $this->toResponse($response);
     }

--- a/tests/Endpoints/Traits/DeletesResource.php
+++ b/tests/Endpoints/Traits/DeletesResource.php
@@ -14,15 +14,14 @@ trait DeletesResource
         $this->client
             ->delete("{$this->endpoint}{$this->resource}/{$uuid}")
             ->shouldBeCalled()
-            ->willReturn($this->successResponse->reveal());
+            ->willReturn(null);
 
         $resource = new $this->endpointClass(
             $this->client->reveal(),
             $this->endpoint
         );
 
-        $this->assertInstanceOf(
-            Response::class,
+        $this->assertNull(
             $resource->delete($uuid)
         );
     }

--- a/tests/Endpoints/Traits/ListsResource.php
+++ b/tests/Endpoints/Traits/ListsResource.php
@@ -7,10 +7,12 @@ use Mirovit\IonicPlatformSDK\Response\Response;
 trait ListsResource
 {
     /** @test */
-    public function it_lists_a_resource_list()
+    public function it_lists_a_resource_list_with_empty_query()
     {
+        $query = ['query' => []];
+
         $this->client
-            ->get("{$this->endpoint}{$this->resource}")
+            ->get("{$this->endpoint}{$this->resource}", $query)
             ->shouldBeCalled()
             ->willReturn($this->successResponse->reveal());
 


### PR DESCRIPTION
Hello 😊 

I was using SDK and noticed some problems.

Ionic updated delete request response and SDK throw exception for no content to body.
https://docs.ionic.io/api/endpoints/push.html#delete-notifications-notification_id
https://docs.ionic.io/api/endpoints/push.html#delete-tokens-token_id
https://docs.ionic.io/api/endpoints/auth.html#delete-users-user_uuid

Also, they added to query options list request for paging and filtering and update SDK for support this too.
https://docs.ionic.io/api/endpoints/auth.html#get-users
https://docs.ionic.io/api/endpoints/push.html#get-notifications
https://docs.ionic.io/api/endpoints/push.html#get-tokens

Thank you for this amazing work, was saved a lot of time on my schedule.
🍻 